### PR TITLE
Reapply Debug Cleanup

### DIFF
--- a/Arduino/VocatusController/DisplayManager.cpp
+++ b/Arduino/VocatusController/DisplayManager.cpp
@@ -117,23 +117,42 @@ void DisplayManager::DebugPrintln(double debugText) { if(_shouldDebug()){ Serial
  * Output a standard debug message to the console with the current state of variables
  */
 void DisplayManager::_sendDebugReport(Record& lifetimeRecord, Record& tonightRecord,Drink& lastDrink) {
-  DebugPrintln(LIFETIME_LABEL);
-  DebugPrintln(SECTION_SEPARATOR);
+  //top separator
+  DebugPrintln(F("================================================="));
 
-  DebugPrintln(lifetimeRecord.count() + " " + _handleSingleCase(lifetimeRecord.count(),LIFECOUNT_UNIT_SINGLE,LIFECOUNT_UNIT));
-  DebugPrintln(LIFESPEED_LABEL + ": " + lifetimeRecord.fastestTime() + " " + LIFESPEED_UNIT);
-  DebugPrintln(LIFEVOLUME_LABEL + ": " + lifetimeRecord.volume() + " " + LIFEVOLUME_UNIT);
+  //Lifetime Header
+  DebugPrint(LIFETIME_LABEL + " - "); DebugPrintln(lifetimeRecord.startTimeString());
+  DebugPrintln(SECTION_SEPARATOR);     DebugPrintln(SECTION_SEPARATOR);
   
-  DebugPrintln(TONIGHT_LABEL);
-  DebugPrintln(SECTION_SEPARATOR);
-    
-  DebugPrintln(TONIGHT_LABEL + ": " + tonightRecord.count() + " " + _handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));
-  DebugPrintln(TONIGHTSPEED_LABEL + ": " + tonightRecord.fastestTime() + " " + TONIGHTSPEED_UNIT);
+  DebugPrintln(lifetimeRecord.count() + " " + _handleSingleCase(lifetimeRecord.count(),LIFECOUNT_UNIT_SINGLE,LIFECOUNT_UNIT));  //Lifetime Info
+  DebugPrint(lifetimeRecord.count()); DebugPrintln(" " + _handleSingleCase(lifetimeRecord.count(),LIFECOUNT_UNIT_SINGLE,LIFECOUNT_UNIT));
+  DebugPrint(lifetimeRecord.volume()); DebugPrintln(" " + GENERIC_TOTAL + " " + LIFEVOLUME_UNIT);
+  DebugPrintln(LIFESPEED_LABEL + ": " + lifetimeRecord.fastestTime() + " " + LIFESPEED_UNIT);     DebugPrintln(LIFESPEED_LABEL + ": " + lifetimeRecord.fastestTime() + " " + LIFESPEED_UNIT);
+  DebugPrintln(LIFEVOLUME_LABEL + ": " + lifetimeRecord.volume() + " " + LIFEVOLUME_UNIT);  DebugPrintln("");
+   
+  DebugPrintln(TONIGHT_LABEL);  //Tonight Header
+  DebugPrint(TONIGHT_LABEL + " - "); DebugPrintln(tonightRecord.startTimeString());
+  DebugPrintln(SECTION_SEPARATOR);    DebugPrintln(SECTION_SEPARATOR);
+
+  //Tonight Info
+  DebugPrintln(TONIGHT_LABEL + ": " + tonightRecord.count() + " " + _handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));     DebugPrintln(TONIGHT_LABEL + ": " + tonightRecord.count() + " " + _handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));
+  DebugPrint(tonightRecord.volume()); DebugPrintln(" " + GENERIC_TOTAL + " " + TONIGHTVOLUME_UNIT);
+  DebugPrintln(TONIGHTSPEED_LABEL + ": " + tonightRecord.fastestTime() + " " + TONIGHTSPEED_UNIT);    DebugPrintln(TONIGHTSPEED_LABEL + ": " + tonightRecord.fastestTime() + " " + TONIGHTSPEED_UNIT);
   DebugPrintln(TONIGHTVOLUME_LABEL + ": " + tonightRecord.volume() + " " + TONIGHTVOLUME_UNIT);
+  DebugPrintln("");
 
-  DebugPrintln(LASTSPEED_LABEL + ": " + lastDrink.timeToFinish() + " " + LASTSPEED_UNIT);
-  DebugPrintln(LASTVOLUME_LABEL + ": " + lastDrink.volume() + " " + LASTVOLUME_UNIT);
+  //Last drink header
+  DebugPrint(LAST_LABEL + " - "); DebugPrintln(lastDrink.endTimeString());
+  DebugPrintln(SECTION_SEPARATOR);
   
+  //Last drink info
+  DebugPrintln(LASTSPEED_LABEL + ": " + lastDrink.timeToFinish() + " " + LASTSPEED_UNIT);     DebugPrintln(LASTSPEED_LABEL + ": " + lastDrink.timeToFinish() + " " + LASTSPEED_UNIT);
+  DebugPrintln(LASTVOLUME_LABEL + ": " + lastDrink.volume() + " " + LASTVOLUME_UNIT);     DebugPrintln(LASTVOLUME_LABEL + ": " + lastDrink.volume() + " " + LASTVOLUME_UNIT);
+
+  //bottom separator 
+  DebugPrintln("");
+  DebugPrintln(F("================================================="));
+  DebugPrintln(F("================================================="));
 }
 
 void DisplayManager::_sendSerialDebugReport(Record& lifetimeRecord, Record& tonightRecord,Drink& lastDrink) {
@@ -310,4 +329,3 @@ void DisplayManager::_sendToLcd(Record& lifetimeRecord, Record& tonightRecord, D
   lcd.setCursor(0,1); 
   lcd.print(toDisplayValue + " " + toDisplayUnit);
 }
-

--- a/Arduino/VocatusController/DisplayManager.cpp
+++ b/Arduino/VocatusController/DisplayManager.cpp
@@ -74,7 +74,7 @@ void DisplayManager::_initDebug() {
 void DisplayManager::OutputData(Record& lifetimeRecord, Record& tonightRecord,Drink& lastDrink)
 {
   if(_isDebugEnabled) {
-    _sendSerialDebugReport(lifetimeRecord,tonightRecord,lastDrink);
+    _sendDebugReport(lifetimeRecord,tonightRecord,lastDrink);
   }
   
   if(_isStatusBoardEnabled) { 
@@ -119,35 +119,35 @@ void DisplayManager::DebugPrintln(double debugText) { if(_shouldDebug()){ Serial
 void DisplayManager::_sendDebugReport(Record& lifetimeRecord, Record& tonightRecord,Drink& lastDrink) {
   //top separator
   DebugPrintln(F("================================================="));
+  DebugPrintln(F("================================================="));
 
   //Lifetime Header
   DebugPrint(LIFETIME_LABEL + " - "); DebugPrintln(lifetimeRecord.startTimeString());
-  DebugPrintln(SECTION_SEPARATOR);     DebugPrintln(SECTION_SEPARATOR);
-  
-  DebugPrintln(lifetimeRecord.count() + " " + _handleSingleCase(lifetimeRecord.count(),LIFECOUNT_UNIT_SINGLE,LIFECOUNT_UNIT));  //Lifetime Info
+  DebugPrintln(SECTION_SEPARATOR);
+
+  //Lifetime Info
   DebugPrint(lifetimeRecord.count()); DebugPrintln(" " + _handleSingleCase(lifetimeRecord.count(),LIFECOUNT_UNIT_SINGLE,LIFECOUNT_UNIT));
   DebugPrint(lifetimeRecord.volume()); DebugPrintln(" " + GENERIC_TOTAL + " " + LIFEVOLUME_UNIT);
-  DebugPrintln(LIFESPEED_LABEL + ": " + lifetimeRecord.fastestTime() + " " + LIFESPEED_UNIT);     DebugPrintln(LIFESPEED_LABEL + ": " + lifetimeRecord.fastestTime() + " " + LIFESPEED_UNIT);
-  DebugPrintln(LIFEVOLUME_LABEL + ": " + lifetimeRecord.volume() + " " + LIFEVOLUME_UNIT);  DebugPrintln("");
-   
-  DebugPrintln(TONIGHT_LABEL);  //Tonight Header
+  DebugPrintln(LIFESPEED_LABEL + ": " + lifetimeRecord.fastestTime() + " " + LIFESPEED_UNIT);
+  DebugPrintln("");
+
+  //Tonight Header
   DebugPrint(TONIGHT_LABEL + " - "); DebugPrintln(tonightRecord.startTimeString());
-  DebugPrintln(SECTION_SEPARATOR);    DebugPrintln(SECTION_SEPARATOR);
+  DebugPrintln(SECTION_SEPARATOR);
 
   //Tonight Info
-  DebugPrintln(TONIGHT_LABEL + ": " + tonightRecord.count() + " " + _handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));     DebugPrintln(TONIGHT_LABEL + ": " + tonightRecord.count() + " " + _handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));
+  DebugPrintln(TONIGHT_LABEL + ": " + tonightRecord.count() + " " + _handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));
   DebugPrint(tonightRecord.volume()); DebugPrintln(" " + GENERIC_TOTAL + " " + TONIGHTVOLUME_UNIT);
-  DebugPrintln(TONIGHTSPEED_LABEL + ": " + tonightRecord.fastestTime() + " " + TONIGHTSPEED_UNIT);    DebugPrintln(TONIGHTSPEED_LABEL + ": " + tonightRecord.fastestTime() + " " + TONIGHTSPEED_UNIT);
-  DebugPrintln(TONIGHTVOLUME_LABEL + ": " + tonightRecord.volume() + " " + TONIGHTVOLUME_UNIT);
+  DebugPrintln(TONIGHTSPEED_LABEL + ": " + tonightRecord.fastestTime() + " " + TONIGHTSPEED_UNIT);
   DebugPrintln("");
 
   //Last drink header
   DebugPrint(LAST_LABEL + " - "); DebugPrintln(lastDrink.endTimeString());
   DebugPrintln(SECTION_SEPARATOR);
-  
+
   //Last drink info
-  DebugPrintln(LASTSPEED_LABEL + ": " + lastDrink.timeToFinish() + " " + LASTSPEED_UNIT);     DebugPrintln(LASTSPEED_LABEL + ": " + lastDrink.timeToFinish() + " " + LASTSPEED_UNIT);
-  DebugPrintln(LASTVOLUME_LABEL + ": " + lastDrink.volume() + " " + LASTVOLUME_UNIT);     DebugPrintln(LASTVOLUME_LABEL + ": " + lastDrink.volume() + " " + LASTVOLUME_UNIT);
+  DebugPrintln(LASTVOLUME_LABEL + ": " + lastDrink.volume() + " " + LASTVOLUME_UNIT);
+  DebugPrintln(LASTSPEED_LABEL + ": " + lastDrink.timeToFinish() + " " + LASTSPEED_UNIT);
 
   //bottom separator 
   DebugPrintln("");
@@ -155,60 +155,71 @@ void DisplayManager::_sendDebugReport(Record& lifetimeRecord, Record& tonightRec
   DebugPrintln(F("================================================="));
 }
 
+/**
+* Method to output the debug info to the monitor directly (without using DebugPrint)
+* Probably no longer needed, but useful in case there's another memory leak problem
+* If we need to free up memory in the code, this whole method can be deleted
+*/
 void DisplayManager::_sendSerialDebugReport(Record& lifetimeRecord, Record& tonightRecord,Drink& lastDrink) {
   Serial.println("");
+  Serial.println(F("================================================="));
+  Serial.println(F("================================================="));
   Serial.print(LIFETIME_LABEL);
-  Serial.print(" - ");
+  Serial.print(F(" - "));
   Serial.println(lifetimeRecord.startTimeString());
   Serial.println(SECTION_SEPARATOR);
   
   Serial.print(lifetimeRecord.count());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(_handleSingleCase(lifetimeRecord.count(),LIFECOUNT_UNIT_SINGLE,LIFECOUNT_UNIT));
 
   Serial.print(lifetimeRecord.volume());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.print(GENERIC_TOTAL);
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(LIFEVOLUME_UNIT);
 
   Serial.print(lifetimeRecord.fastestTime());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(LIFESPEED_UNIT);
 
   Serial.println("");
 
   Serial.print(TONIGHT_LABEL);
-  Serial.print(" - ");
+  Serial.print(F(" - "));
   Serial.println(tonightRecord.startTimeString());
   Serial.println(SECTION_SEPARATOR);
   
   Serial.print(tonightRecord.count());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(_handleSingleCase(tonightRecord.count(),TONIGHTCOUNT_UNIT_SINGLE,TONIGHTCOUNT_UNIT));
 
   Serial.print(tonightRecord.volume());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.print(GENERIC_TOTAL);
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(TONIGHTVOLUME_UNIT);
   
   Serial.print(tonightRecord.fastestTime());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(TONIGHTSPEED_UNIT);
   Serial.println("");
 
-  Serial.print("Last Drink - ");
+  Serial.print(F("Last Drink - "));
   Serial.println(lastDrink.endTimeString());
   Serial.println(SECTION_SEPARATOR);
 
   Serial.print(lastDrink.volume());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(LASTVOLUME_UNIT);
 
   Serial.print(lastDrink.timeToFinish());
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.println(LASTSPEED_UNIT);
+  
+  Serial.println();
+  Serial.println(F("================================================="));
+  Serial.println(F("================================================="));
 }
 
 /****************************************************************/

--- a/Arduino/VocatusController/DisplayManager.h
+++ b/Arduino/VocatusController/DisplayManager.h
@@ -37,24 +37,26 @@ const String LIFEVOLUME_UNIT          = "mL";
 const String LIFESPEED_LABEL          = "All-Time Record";
 const String LIFESPEED_UNIT           = "ms";
 
-const String TONIGHT_LABEL       = "Tonight";
+const String TONIGHT_LABEL            = "Tonight";
 const String TONIGHTCOUNT_UNIT        = "drinks";
 const String TONIGHTCOUNT_UNIT_SINGLE = "drink";
 
 const String TONIGHTSPEED_LABEL       = "Tonight's Record";
 const String TONIGHTSPEED_UNIT        = "ms";
-const String LASTSPEED_LABEL          = "Last Drink";
-const String LASTSPEED_UNIT           = "ms";
 
 const String TONIGHTVOLUME_LABEL      = "Tonight's Volume";
 const String TONIGHTVOLUME_UNIT       = "mL";
+
+const String LAST_LABEL               = "Last Drink";
+
+const String LASTSPEED_LABEL          = "Last Drink";
+const String LASTSPEED_UNIT           = "ms";
+
 const String LASTVOLUME_LABEL         = "Last Volume";
 const String LASTVOLUME_UNIT          = "mL";
 
 const String SECTION_SEPARATOR        = "----------";
-const String GENERIC_FASTEST          = "Fastest Time ";
 const String GENERIC_TOTAL            = "total";
-const String COLON_SEPARATOR          = ": ";
 
 class DisplayManager
 {

--- a/Arduino/VocatusController/DisplayManager.h
+++ b/Arduino/VocatusController/DisplayManager.h
@@ -49,11 +49,11 @@ const String TONIGHTVOLUME_UNIT       = "mL";
 
 const String LAST_LABEL               = "Last Drink";
 
-const String LASTSPEED_LABEL          = "Last Drink";
-const String LASTSPEED_UNIT           = "ms";
-
 const String LASTVOLUME_LABEL         = "Last Volume";
 const String LASTVOLUME_UNIT          = "mL";
+
+const String LASTSPEED_LABEL          = "Last Drink";
+const String LASTSPEED_UNIT           = "ms";
 
 const String SECTION_SEPARATOR        = "----------";
 const String GENERIC_TOTAL            = "total";

--- a/Arduino/VocatusController/VocatusController.ino
+++ b/Arduino/VocatusController/VocatusController.ino
@@ -151,11 +151,9 @@ void loop() {
   //timeManager.manageTime();
   
   if(isDrinkOver()) {
-    outputFreeMemory();
     recordDrinkEnd();
     printStatusReport();
     resetCurrentDrink();
-    outputFreeMemory();
   }
 }
 

--- a/Arduino/VocatusController/VocatusController.ino
+++ b/Arduino/VocatusController/VocatusController.ino
@@ -151,9 +151,11 @@ void loop() {
   //timeManager.manageTime();
   
   if(isDrinkOver()) {
+    outputFreeMemory();
     recordDrinkEnd();
     printStatusReport();
     resetCurrentDrink();
+    outputFreeMemory();
   }
 }
 
@@ -361,4 +363,31 @@ void readFromStorage() {
  */
 void storeAllValues() {
   storage.storeAllValues(lifetime,tonight);
+}
+
+#ifdef __arm__
+// should use uinstd.h to define sbrk but Due causes a conflict
+extern "C" char* sbrk(int incr);
+#else  // __ARM__
+extern char *__brkval;
+#endif  // __arm__
+ 
+int freeMemory() {
+  char top;
+#ifdef __arm__
+  return &top - reinterpret_cast<char*>(sbrk(0));
+#elif defined(CORE_TEENSY) || (ARDUINO > 103 && ARDUINO != 151)
+  return &top - __brkval;
+#else  // __arm__
+  return __brkval ? &top - __brkval : &top - __malloc_heap_start;
+#endif  // __arm__
+}
+
+/**
+ * outputs a string telling the total free memory at the time the method was called (distance between heap and stack)
+ * Used to track memory leaks
+ */
+void outputFreeMemory() {
+  Serial.print(F("Memory: "));
+  Serial.println(freeMemory());
 }


### PR DESCRIPTION
Reapply the debug cleanup code following the reverts. Turns out the issue was that the header file was defining a long string (to be used as a separator in the output). Simply removing that declaration and replacing all instances with the string constant fixed the issue. It also freed up some more memory.
Also adding back some of the previous functionality.